### PR TITLE
Add `Invisible` style

### DIFF
--- a/src/style.rs
+++ b/src/style.rs
@@ -13,6 +13,7 @@ pub enum Style {
     Filled,
     Striped,
     Wedged,
+    Invisible,
 }
 
 impl std::fmt::Display for Style {
@@ -28,6 +29,7 @@ impl std::fmt::Display for Style {
             Self::Filled => "filled",
             Self::Striped => "striped",
             Self::Wedged => "wedged",
+            Self::Invisible => "invis",
         };
 
         write!(f, "{s}")


### PR DESCRIPTION
Hey, thanks for this cool crate.
This is a fairly small change, but I added `Style::Invisible` since it allows us to format the graph structure flexibly.